### PR TITLE
Add Dependabot auto-approve workflow

### DIFF
--- a/.github/workflows/dependabot-approve.yaml
+++ b/.github/workflows/dependabot-approve.yaml
@@ -1,0 +1,10 @@
+name: Dependabot auto-merge
+on: pull_request
+
+jobs:
+  dependabot:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: landlordhq/github-actions-workflows/.github/workflows/check-dependabot-pr.yaml@main
+    with:
+      level: automerge
+    secrets: inherit


### PR DESCRIPTION
Adds the standard Dependabot auto-approve stub (canonical copy from [roz](https://github.com/landlordhq/roz/blob/main/.github/workflows/dependabot-approve.yaml)) so this repo's Dependabot PRs go through the shared reviewed-automerge workflow.

<details>
<summary>AI Description</summary>

This repo has a `.github/dependabot.yml` but no workflow to handle the PRs Dependabot opens, so they sit until a human reviews them. This adds the org-standard stub, byte-identical to the canonical version in roz:

- Triggers on `pull_request`, gated to `dependabot[bot]`-authored PRs.
- Delegates to the reusable `landlordhq/github-actions-workflows/.github/workflows/check-dependabot-pr.yaml@main` with `level: automerge`, which reviews the bump with Claude and, when nothing CI-invisible needs a human, approves and enables auto-merge (CI still gates the actual merge). If there is a concern, it leaves a comment instead of approving.
- `secrets: inherit` passes through the org secrets the reusable workflow needs (`PR_APPROVE_MERGE_PAT`, `ANTHROPIC_PLATFORM_API_KEY`, `CHECKOUT_SUBMODULES_PAT`).

Part of an org-wide sweep ensuring every repo with a Dependabot config has this workflow.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
